### PR TITLE
fix crash when clipboard owner process terminates

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -4047,14 +4047,15 @@ namespace ClipAngel
             Process process = ProcessFromWindow(hwnd);
             if (process == null)
                 return result;
-            result.processId = process.Id;
             try
             {
+                result.processId = process.Id;
                 result.application = process.ProcessName;
                 hwnd = process.MainWindowHandle;
             }
-            catch (Exception e)
+            catch (Exception)
             {
+                // process terminated before we could read it
                 return result;
             }
             result.appPath = GetProcessMainModuleFullName(result.processId);


### PR DESCRIPTION
Fixes crash when a process copies to clipboard and terminates before ClipAngel can read its info.