### PR TITLE
Fix .NET Framework bootstrapper version

### DIFF
--- a/ClipAngel.csproj
+++ b/ClipAngel.csproj
@@ -636,9 +636,9 @@
     <None Include="Picture\FindPrevious.png" />
   </ItemGroup>
   <ItemGroup>
-    <BootstrapperPackage Include=".NETFramework,Version=v4.5.2">
+    <BootstrapperPackage Include=".NETFramework,Version=v4.8">
       <Visible>False</Visible>
-      <ProductName>Microsoft .NET Framework 4.5.2 %28x86 and x64%29</ProductName>
+      <ProductName>Microsoft .NET Framework 4.8 %28x86 and x64%29</ProductName>
       <Install>true</Install>
     </BootstrapperPackage>
     <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">


### PR DESCRIPTION
Обновление BootstrapperPackage с .NET Framework 4.5.2 до 4.8 для соответствия целевой версии .NET Framework проекта.